### PR TITLE
Fixed twitter share && removed google+ share

### DIFF
--- a/clean-blog/index.twig
+++ b/clean-blog/index.twig
@@ -132,7 +132,7 @@
                         </li>
 					{% endfor %}
                     </ul>
-                    <p class="copyright text-muted">Copyright &copy; {{ site_title }} 2016</p>
+                    <p class="copyright text-muted">Copyright &copy; {{ site_title }} 2019</p>
                 </div>
             </div>
         </div>

--- a/clean-blog/post.twig
+++ b/clean-blog/post.twig
@@ -96,7 +96,7 @@
                 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                     <ul class="list-inline text-center">
                         <li>
-                            <a href="https://twitter.com/home?status={{ current_page.url }}" target="_blank" rel="noopener noreferrer">
+                            <a href="https://twitter.com/share?text=Read {{ current_page.title }} by {{ current_page.author}}&url={{ current_page.url }}" target="_blank" rel="noopener noreferrer">
                                 <span class="fa-stack fa-lg">
                                     <i class="fa fa-circle fa-stack-2x"></i>
                                     <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
@@ -111,16 +111,8 @@
                                 </span>
                             </a>
                         </li>
-                        <li>
-                            <a href="https://plus.google.com/share?url={{ current_page.url }}" target="_blank" rel="noopener noreferrer">
-                                <span class="fa-stack fa-lg">
-                                    <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-google-plus fa-stack-1x fa-inverse"></i>
-                                </span>
-                            </a>
-                        </li>
                     </ul>
-                    <p class="copyright text-muted">Copyright &copy; {{ site_title }} 2016</p>
+                    <p class="copyright text-muted">Copyright &copy; {{ site_title }} 2019</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Fixed twitter share not working
Twitter share was not working, redirecting to https://twitter.com/home?status={{ current_page.url }} instead of https://twitter.com/share?url={{ current_page.url }}, resulting in the twitter home being displayed instead of share intent when the user clicks on the url. Fixed it as well as adding "Read {{current_page.title}} by {{current_page.author}}" message as default tweet text.
### Removed Google+ share button
Google+ is dead, so I removed the Google+ share link from post.twig.